### PR TITLE
Upgrade highlight.run

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ module.exports = {
       resolve: "@highlight-run/gatsby-plugin-highlight",
       options: {
         orgID: 'MY_ORG_ID',
-        // See all the options here: https://docs.highlight.run/reference#options
+        // See all the options here: https://www.highlight.io/docs/sdk/client#options
     	disableNetworkRecording: false,
     	disableConsoleRecording: false,
     	enableStrictPrivacy: false,
@@ -22,7 +22,7 @@ module.exports = {
 }
 ```
 
-Options will be passed directly to `H.init`. See all available options in [our docs](https://docs.highlight.run/reference#importing-the-library).
+Options will be passed directly to `H.init`. See all available options in [our docs](https://www.highlight.io/docs/sdk/client#options).
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ module.exports = {
       options: {
         orgID: 'MY_ORG_ID',
         // See all the options here: https://www.highlight.io/docs/sdk/client#options
-    	disableNetworkRecording: false,
-    	disableConsoleRecording: false,
-    	enableStrictPrivacy: false,
+        disableNetworkRecording: false,
+        disableConsoleRecording: false,
+        enableStrictPrivacy: false,
    	    environment: 'production',
-    	version: '5.2.3',
-    	networkRecording: true,
+        version: '5.2.3',
+        networkRecording: true,
       }
     },
   ]

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -3,7 +3,7 @@ const Highlight = require("highlight.run");
 exports.onClientEntry = (_, pluginOptions) => {
   const { orgID, plugins, ...options } = pluginOptions;
 
-  Highlight.H.init(orgID, options.options);
+  Highlight.H.init(orgID, options);
 
   // @ts-ignore
   window.H = Highlight.H;

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@highlight-run/gatsby-plugin-highlight",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Gatsby plugin for adding Highlight error monitoring and session recording.",
   "main": "index.js",
   "repository": "git@github.com:highlight-run/gatsby-plugin-highlight.git",
   "author": "John Pham <john@highlight.run>",
   "license": "MIT",
   "dependencies": {
-    "highlight.run": "^8.8.0"
+    "highlight.run": "^8.12.3"
   },
   "keywords": [
     "highlight",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-highlight.run@^8.8.0:
-  version "8.8.0"
-  resolved "https://registry.yarnpkg.com/highlight.run/-/highlight.run-8.8.0.tgz#616426d0ddc36dd653e0db3cd9089368a2f9b608"
-  integrity sha512-giGSKqS0thINMfNXhiQbRy5UcRDtUM51a/UoKWpsih39m0Y9XBzuPgkTLDJGVaPL7CWtZwOSaE1bIkflYaGUYA==
+highlight.run@^8.12.3:
+  version "8.12.3"
+  resolved "https://registry.yarnpkg.com/highlight.run/-/highlight.run-8.12.3.tgz#5bdcec9b3f6eff2ec35644d67863483f06bbf92c"
+  integrity sha512-zqGxump2Bfehc2nyuWJ8wxoA7CCfsBJoYnGSUuB8nbzfvipM8o9bsBo6XJOmn8F0bVw67fWXRrst7hF4lqYE+A==


### PR DESCRIPTION
Upgrades the highlight.run package to v8.12.3 (latest). This should resolve an issue with reporting web vitals.

Also updates the README and fixes a bug in the code passing options to the `init` call. I noticed my `backendUrl` option wasn't being passed as expected to send data to my local instance of Highlight for testing and noticed we're trying to pass `options.options` which ends up being `undefined`.

<img width="394" alt="Screenshot 2024-05-16 at 12 39 12 PM" src="https://github.com/highlight/gatsby-plugin-highlight/assets/308182/cf22a8a8-7f85-4043-b388-114a62b97a14">

Linear Ticket: [SUP-22 : gatsby plugin should be updated to use the latest client](https://linear.app/highlight/issue/SUP-22/gatsby-plugin-should-be-updated-to-use-the-latest-client)