### PR TITLE
Fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ Options will be passed directly to `H.init`. See all available options in [our d
 
 ## Links
 
-- [Official SDK Docs](https://docs.highlight.run/reference#overview)
-- [Website](https://highlight.run)
+- [Official SDK Docs](https://highlight.io/docs)
+- [Website](https://highlight.io)


### PR DESCRIPTION
Fixes some broken links I noticed while digging through the [ahrefs broken links report](https://app.ahrefs.com/v2-site-explorer/best-by-links?anchorRules=&bestFilter=all&domainNameRules=&externalLimit=50&externalOffset=0&externalSort=RefDomains&externalSortDirection=desc&followType=all&highlightChanges=30d&history=all&internalLimit=50&internalOffset=0&internalSort=LinksToTarget&internalSortDirection=desc&mode=subdomains&refPageAuthorRules=&refPageTitleRules=&refPageUrlRules=&selectedTab=external&surroundingRules=&target=highlight.io%2F&targetHttpCode=404&targetPageTitleRules=&targetUrlRules=).